### PR TITLE
Fix REST query parameter bug

### DIFF
--- a/workbench/controllers/RestExplorerController.php
+++ b/workbench/controllers/RestExplorerController.php
@@ -71,6 +71,7 @@ class RestExplorerController {
 
         if (in_array($this->requestMethod, RestApiClient::getMethodsWithBodies()) && trim($this->requestBody) == "") {
             if (stripos($this->requestHeaders, "Content-Type: application/json") !== false) {
+                // If nothing's specified in the JSON body, set it to null.
                 $this->requestBody = "null";
             }
             else {

--- a/workbench/controllers/RestExplorerController.php
+++ b/workbench/controllers/RestExplorerController.php
@@ -70,7 +70,7 @@ class RestExplorerController {
         $this->url = str_replace(' ', '+', trim($this->url));
 
         if (in_array($this->requestMethod, RestApiClient::getMethodsWithBodies()) && trim($this->requestBody) == "") {
-            throw new WorkbenchHandledException("Must include a Request Body.");
+            $this->requestBody = "null";
         }
     }
 

--- a/workbench/controllers/RestExplorerController.php
+++ b/workbench/controllers/RestExplorerController.php
@@ -70,7 +70,12 @@ class RestExplorerController {
         $this->url = str_replace(' ', '+', trim($this->url));
 
         if (in_array($this->requestMethod, RestApiClient::getMethodsWithBodies()) && trim($this->requestBody) == "") {
-            $this->requestBody = "null";
+            if (stripos($this->requestHeaders, "Content-Type: application/json") !== false) {
+                $this->requestBody = "null";
+            }
+            else {
+                throw new WorkbenchHandledException("Must include a Request Body.");
+            }
         }
     }
 

--- a/workbench/put.php
+++ b/workbench/put.php
@@ -409,7 +409,7 @@ function setFieldMappings($action,$csvArray) {
                 if ($currRecord == null) {
                     displayUploadFileWithObjectSelectionForm($action, $id,
                                                              "An existing " . WorkbenchContext::get()->getDefaultObject() .
-                                                             " could not found with the id '$id'. Confirm both the object type and id are correct.");
+                                                             " could not be found with the id '$id'. Confirm both the object type and id are correct.");
                     exit;
                 }
             }


### PR DESCRIPTION
This is a fix for https://github.com/ryanbrainard/forceworkbench/issues/581.

When passing an "url" parameter to the REST Explorer, that parameter needs to have its ampersands URL-encoded so that they aren’t treated as separate query parameters in the top-level request.
