### PR TITLE
Fix streaming issue for OSX

### DIFF
--- a/workbench/restclient/RestClient.php
+++ b/workbench/restclient/RestClient.php
@@ -117,7 +117,7 @@ class RestApiClient {
         curl_setopt($ch, CURLOPT_HEADER, $expectBinary ? 0 : 1);
         curl_setopt($ch, CURLOPT_BINARYTRANSFER, $expectBinary ? 1 : 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);                                //TODO: use ca-bundle instead
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);                                //TODO: use ca-bundle instead
         curl_setopt($ch, CURLOPT_SSLVERSION, 6);
 
         if ($this->proxySettings != null) {

--- a/workbench/util/PhpReverseProxy.php
+++ b/workbench/util/PhpReverseProxy.php
@@ -80,7 +80,7 @@ class PhpReverseProxy {
         curl_setopt($ch, CURLOPT_URL, $this->translateURL($this->host));
 
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0); //TODO: use ca-bundle instead
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1); //TODO: use ca-bundle instead
         curl_setopt($ch, CURLOPT_SSLVERSION, 6);
 
         if ($this->proxy_settings != null) {


### PR DESCRIPTION
When disabled, it throws an error when going on the streaming tab: "SSL: CA certificate set, but certificate verification is disabled"