### PR TITLE
Modifications to get forceworkbench on packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
+    "name": "forceworkbench/forceworkbench",
+    "type": "library",
+    "description": "Force Workbench is a powerful, web-based suite of tools designed for administrators and developers to interact with Salesforce.com organizations via the Force.com APIs. Workbench includes robust support for the Force.com Partner, Bulk, Rest, Streaming, Metadata, and Apex APIs that allows users to describe, query, manipulate, and migrate both data and metadata in Salesforce.com organizations directly in their web browser with a simple and intuitive user interface. Workbench also provides many advanced features for testing and troubleshooting the Force.com APIs, such as customizable SOAP headers, debug logs for API traffic, backward compatibility testing with previous API versions, and single sign-on integration within the Salesforce application.",
+    "keywords": ["salesforce", "php", "workbench"],
+    "homepage": "https://github.com/forceworkbench/forceworkbench",
     "require": {
         "php": "~5.6.12",
         "ext-redis": "*",


### PR DESCRIPTION
I'd like to do ```composer install forceworkbench/forceworkbench``` , but that requires that there is a name field in the composer.json and that this repo is submitted to https://packagist.org/packages/submit .   Would you please approve this change?  I think this will help adoption as I believe this is how most PHP developers add packages.