### PR TITLE
Tighten permissions around php-fhm locally

### DIFF
--- a/fpm_custom.conf
+++ b/fpm_custom.conf
@@ -1,6 +1,3 @@
-user = daemon
-group = daemon
-listen.owner = daemon
 listen.group = daemon
 listen.mode = 0660
 php_value[always_populate_raw_post_data]=-1

--- a/fpm_custom.conf
+++ b/fpm_custom.conf
@@ -1,1 +1,6 @@
+user = daemon
+group = daemon
+listen.owner = daemon
+listen.group = daemon
+listen.mode = 0660
 php_value[always_populate_raw_post_data]=-1

--- a/fpm_custom_local.conf
+++ b/fpm_custom_local.conf
@@ -1,2 +1,6 @@
-listen.mode = 0666
+user = daemon
+group = daemon
+listen.owner = daemon
+listen.group = daemon
+listen.mode = 0660
 php_value[always_populate_raw_post_data]=-1

--- a/fpm_custom_local.conf
+++ b/fpm_custom_local.conf
@@ -1,6 +1,3 @@
-user = daemon
-group = daemon
-listen.owner = daemon
 listen.group = daemon
 listen.mode = 0660
 php_value[always_populate_raw_post_data]=-1


### PR DESCRIPTION
Have been working on the permissions of the [PHP buildpack](https://github.com/heroku/heroku-buildpack-php) with the maintainer. These permissions enable PHP FastCGI to run both in Heroku and locally.

These changes will eventually make its way into the PHP buildpack, but, for now, let's put them here first.