### PR TITLE
Use new PHP buildpack for local docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM heroku/heroku:16-build as base
 
-ENV PHP_BUILDPACK_VERSION v143
+ENV PHP_BUILDPACK_VERSION v144
 ENV APP /app
 ENV HOME $APP
 ENV HEROKU_PHP_BIN $APP/.heroku/php/bin

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,4 +12,4 @@ function fix_linux_internal_host() {
 }
 
 fix_linux_internal_host
-vendor/bin/heroku-php-apache2 -F fpm_custom_local.conf -i local_php.ini workbench
+vendor/bin/heroku-php-apache2 -F fpm_custom.conf -i local_php.ini workbench

--- a/fpm_custom_local.conf
+++ b/fpm_custom_local.conf
@@ -1,2 +1,0 @@
-listen.mode = 0666
-php_value[always_populate_raw_post_data]=-1


### PR DESCRIPTION
The new PHP buildpack (v144) now uses 0666 for the listen mode. See https://github.com/heroku/heroku-buildpack-php/pull/296

We don't have to use our local configuration now.