### PR TITLE
remove Autoloader to fix installation issue #764

### DIFF
--- a/workbench/shared.php
+++ b/workbench/shared.php
@@ -1,5 +1,5 @@
 <?php
-require __DIR__ . '/../vendor/autoload.php';
+//require __DIR__ . '/../vendor/autoload.php';
 require_once "util/ErrorLogging.php";
 require_once "util/ExpandableTree.php";
 


### PR DESCRIPTION
- this path depends on users PHP webserver installation/configuration
- eg. crashes if in a different location than the built-in XAMP/WAMP
- crashes the whole application when broken leading to issue (#764)