### PR TITLE
Build pack version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM heroku/heroku:16-build as base
 
-ENV PHP_BUILDPACK_VERSION v144
+ENV PHP_BUILDPACK_VERSION v148
 ENV APP /app
 ENV HOME $APP
 ENV HEROKU_PHP_BIN $APP/.heroku/php/bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     ports:
       - '8080:8080'
   redis:
-    image: redis:alpine
+    image: redis:3.2
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     ports:
       - '8080:8080'
   redis:
-    image: redis:3.2
+    image: redis:alpine
     ports:
       - "6379:6379"


### PR DESCRIPTION
Changes php buildpack from v144 to v148. We began hitting this error during the builds: 

> ERROR: Failed to download minimal PHP for bootstrapping!

Updating the php builpack to the latest version (148) clears this error. 