### PR TITLE
Separate secrets.php from overrides.php 

### DIFF
--- a/workbench/config/WorkbenchConfig.php
+++ b/workbench/config/WorkbenchConfig.php
@@ -45,6 +45,12 @@ class WorkbenchConfig {
             require 'configOverrides.php';
         }
 
+        // load file-based secrets
+        if (is_file('config/secrets.php')) {
+            /** @noinspection PhpIncludeInspection */
+            require 'config/secrets.php';
+        }
+
         // unset from global namespace
         $this->config = $config;
         unset($config);

--- a/workbench/config/defaults.php
+++ b/workbench/config/defaults.php
@@ -2,8 +2,10 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 //    TO CONFIGURE WORKBENCH FOR ALL YOUR USERS, ADJUST THE "DEFAULT" VALUES FOR THE KEYS BELOW.
-//    FOR EASIER UPGRADING, YOU MAY IT IS RECOMMENDED TO MAKE THESE CHANGES TO THE overrides.php FILE
-//    WHICH ARE APPLIED AFTER LOADING CONFIGURATIONS FROM THIS FILE.
+//    FOR EASIER UPGRADING, IT IS RECOMMENDED TO MAKE THESE CHANGES TO THE overrides.php FILE
+//    INSTEAD OF MAKING ANY CHANGES TO THIS FILE DIRECTLY. IN ADDITION, A secrets.php FILE
+//    MAY ALSO BE PROVIDED TO LOAD ANY SECRETS THAT YOU WOULD LIKE TO KEEP SEPARATE FROM OTHER OVERRIDES.
+//    THE FILES ARE LOADED IN THE ORDER: 1) defaults.php, 2) overrides.php, 3) secrets.php
 //
 //    IF YOU WOULD LIKE TO ALLOW YOUR USERS TO OVERRIDE THE DEFAULTS SET THE "OVERRIDEABLE" VALUE TO true.
 //    THIS WILL CAUSE THE KEY TO APPEAR ON THE 'SETTINGS' PAGE AND WILL BE CUSTOMIZABLE ON A USER-BY-USER
@@ -869,7 +871,7 @@ $config["header_Performance"] = array(
         "dataType" => "boolean"
     );
 
-    // This should never be overrideable by end users; instead, admins SHOULD override default in overrides.php
+    // This should never be overrideable by end users; instead, admins SHOULD override default in secrets.php
     $config["csrfSecret"] = array(
         "label" => "CSRF Salting Secret",
         "description" => "Used for salting the CSRF (Cross-Site Request Forgery) tokens.",
@@ -878,7 +880,7 @@ $config["header_Performance"] = array(
         "dataType" => "string"
     );
 
-    // This should never be overrideable by end users; instead, admins SHOULD override default in overrides.php
+    // This should never be overrideable by end users; instead, admins SHOULD override default in secrets.php
     $config["sodiumKey"] = array(
         "label" => "Libsodium Encryption Key",
         "description" => "Used for salting libsodium encryption.",
@@ -887,7 +889,7 @@ $config["header_Performance"] = array(
         "dataType" => "string"
     );
 
-    // This should never be overrideable by end users; instead, admins SHOULD override default in overrides.php
+    // This should never be overrideable by end users; instead, admins SHOULD override default in secrets.php
     $config["nonce"] = array(
         "label" => "Nonce For libsodium Encryption",
         "description" => "required nonce value for libsodium encryption.",
@@ -923,7 +925,7 @@ $config["header_Performance"] = array(
         "dataType" => "boolean"
     );
 
-    // This should never be overrideable by end users; instead, admins SHOULD override default in overrides.php
+    // This should never be overrideable by end users; instead, admins SHOULD override default in secrets.php
     $config["oauthConfigs"] = array(
         "label" => "OAuth 2.0 Consumer Key",
         "description" => "OAuth 2.0 Consumer Key",

--- a/workbench/config/overrides.php
+++ b/workbench/config/overrides.php
@@ -3,6 +3,7 @@
 //
 // THIS FILE IS INTENDED FOR ADVANCED ADMINS ONLY TO OVERRIDE THE ARRAYS OR COMPONENT OF ARRAYS IN
 // THE defaults.php FILE WITH CUSTOMIZATIONS TO APPLY TO ALL YOUR WORKBENCH USERS.
+// SEE ALSO secrets.php FOR SECRET OVERRIDES.
 //
 // THIS IS NOT TO BE CONFUSED WITH THE overrideable BOOLEAN FLAG WITHIN THE CONFIGURATIONS TO ALLOW
 // END USERS TO CUSTOMIZE IN SETTINGS. SEE defaults.php FOR DETAILS.
@@ -10,40 +11,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // EXAMPLE: $config["fuzzyServerUrlLookup"]["default"] = false;
-
-
-// OAUTH 2.0 SETTINGS
-// Uncomment and populate with keys and secrets to enable OAuth.
-// Note, Production and Sandbox can have the same key and secret, but it is not required
-// If connecting to other Salesforce environments, add a new entry to the array:
 //
-//$config["oauthConfigs"]["default"] = array(
-//                                            "login.salesforce.com" => array(
-//                                                "label" => "Production",
-//                                                "key" => "",
-//                                                "secret" => ""
-//                                            ),
-//                                            "test.salesforce.com" => array(
-//                                                "label" => "Sandbox",
-//                                                "key" => "",
-//                                                "secret" => ""
-//                                            )
-//                                        );
-
-
-// CSRF SECURITY SETTINGS
-// Uncomment and change the value below to a random, secret value:
-//
-// $config["csrfSecret"]["default"] = "CHANGE_ME";
-
-/* SODIUM ENCRYPTION KEY AND NONCE SETTINGS
-It is recommended that you change the values below to custom strings.
-    -The sodiumKey must be 64 characters long
-    -The nonce must be 24 characters long
- */
-$config["sodiumKey"]["default"] = "T8TAoGtlCWOwWrFFRjTThFDn9+iGsGGjhvALbWkSONN4KyDNbI2VNZmm+sCiM5X7";
-$config["nonce"]["default"] = "aojzmL4AKy1s5T5JnQ1yn+2U";
-
 // ORG ID WHITELIST / BLACKLIST
 // To only allow access to a set of orgs or block access to particular orgs,
 // uncomment and add the orgs to the respective lists below as comma-separated values:

--- a/workbench/config/secrets.php
+++ b/workbench/config/secrets.php
@@ -1,0 +1,40 @@
+<?php
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// THIS FILE IS INTENDED FOR ADVANCED ADMINS ONLY TO SET SECRETS THAT OVERRIDE VALUES IN default.php
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// OAUTH 2.0 SETTINGS
+// Uncomment and populate with keys and secrets to enable OAuth.
+// Note, Production and Sandbox can have the same key and secret, but it is not required
+// If connecting to other Salesforce environments, add a new entry to the array:
+//
+//$config["oauthConfigs"]["default"] = array(
+//                                            "login.salesforce.com" => array(
+//                                                "label" => "Production",
+//                                                "key" => "",
+//                                                "secret" => ""
+//                                            ),
+//                                            "test.salesforce.com" => array(
+//                                                "label" => "Sandbox",
+//                                                "key" => "",
+//                                                "secret" => ""
+//                                            )
+//                                        );
+
+
+// CSRF SECURITY SETTINGS
+// Uncomment and change the value below to a random, secret value:
+//
+// $config["csrfSecret"]["default"] = "CHANGE_ME";
+
+/* SODIUM ENCRYPTION KEY AND NONCE SETTINGS
+It is recommended that you change the values below to custom strings.
+    -The sodiumKey must be 64 characters long
+    -The nonce must be 24 characters long
+ */
+$config["sodiumKey"]["default"] = "T8TAoGtlCWOwWrFFRjTThFDn9+iGsGGjhvALbWkSONN4KyDNbI2VNZmm+sCiM5X7";
+$config["nonce"]["default"] = "aojzmL4AKy1s5T5JnQ1yn+2U";
+
+?>


### PR DESCRIPTION
When using file-based config in environments that make a distinction between config and secrets (e.g. Kubernetes), it can helpful to have a separate `secrets.php` file to be loaded. From Workbench's perspective, there is no difference between `overrides.php` and `secrets.php` (except that `secrets.php` is loaded last), but can be helpful for some deployments. This is strictly optional, but is documented as the suggested approach.