### PR TITLE
enables upsert for case and other objects with readonly name field

### DIFF
--- a/workbench/put.php
+++ b/workbench/put.php
@@ -523,7 +523,7 @@ function setFieldMappings($action,$csvArray) {
     if ($action == 'upsert') {
         printPutFieldForMappingId($csvArray, true, $currRecord);
         foreach ($describeSObjectResult->fields as $field) {
-            if ($field->updateable && $field->createable) {
+            if ($field->nameField || ($field->updateable && $field->createable)) {
                 printPutFieldForMapping($field, $csvArray, true, $currRecord);
             }
         }


### PR DESCRIPTION
Per [this question](https://salesforce.stackexchange.com/q/353729/2984), you cannot upsert against cases by case number. This would be useful if you only had the case number and wanted to use it as an External Id. This small patch allows upserting cases and other objects that do not allow their name field to be createable/updateable to update records correctly.