### PR TITLE
Redis session handler with TLS support

### DIFF
--- a/.profile.d/heroku-setup.sh
+++ b/.profile.d/heroku-setup.sh
@@ -1,13 +1,11 @@
 if [ -n "$REDISTOGO_URL" ]; then
   echo "Configuring RedisToGo"
   export forceworkbench__redisUrl__default="$REDISTOGO_URL"
-  export forceworkbench__sessionStore__default="$REDISTOGO_URL"
 fi
 
 if [ -n "$REDIS_URL" ]; then
   echo "Configuring Redis"
   export forceworkbench__redisUrl__default="$REDIS_URL"
-  export forceworkbench__sessionStore__default="$REDIS_URL"
 fi
 
 if [ "$forceworkbench__logHandler__default" = "file" ] && [ "$forceworkbench__logFile__default" = "/app/target/app.log" ]; then

--- a/workbench/config/defaults.php
+++ b/workbench/config/defaults.php
@@ -1001,15 +1001,7 @@ $config["header_internal"] = array(
 
     $config["redisUrl"] = array(
         "label" => "Redis URL",
-        "description" => "Redis URL used for async processing.",
-        "default" => "",
-        "overrideable" => false,
-        "dataType" => "string"
-    );
-
-    $config["sessionStore"] = array(
-        "label" => "Session Store",
-        "description" => "Only redis:// URL are currently supported; otherwise, blank for default value",
+        "description" => "Redis URL used for sessions and async processing.",
         "default" => "",
         "overrideable" => false,
         "dataType" => "string"

--- a/workbench/footer.php
+++ b/workbench/footer.php
@@ -34,12 +34,12 @@ if (isset($_REQUEST["footerScripts"])) {
 </html>
 
 <?php
-$peak = memory_get_peak_usage();
-workbenchLog(LOG_INFO, "MemoryUsageCheck", array("measure.memory.peak" => $peak . "byte"));
-if (WorkbenchContext::isEstablished() && ($peak/toBytes(ini_get("memory_limit"))) > 0.7) {
-   WorkbenchContext::get()->clearCache();
-   workbenchLog(LOG_INFO, "MemoryUsageCacheClear", array("measure.memory.cache_clear" => 1));
-}
+//$peak = memory_get_peak_usage();
+//workbenchLog(LOG_INFO, "MemoryUsageCheck", array("measure.memory.peak" => $peak . "byte"));
+//if (WorkbenchContext::isEstablished() && ($peak/toBytes(ini_get("memory_limit"))) > 0.7) {
+//   WorkbenchContext::get()->clearCache();
+//   workbenchLog(LOG_INFO, "MemoryUsageCacheClear", array("measure.memory.cache_clear" => 1));
+//}
 
 if (isset($GLOBALS['REDIS'])) {
     redis()->close();

--- a/workbench/shared.php
+++ b/workbench/shared.php
@@ -168,13 +168,23 @@ function usingSslEndToEnd() {
     return usingSslFromUserToWorkbench() && usingSslFromWorkbenchToSfdc();
 }
 
-function toBytes ($size_str) {
-    switch (substr ($size_str, -1)) {
-        case 'G': case 'g': $size_str *= 1024;
-        case 'M': case 'm': $size_str *= 1024;
-        case 'K': case 'k': $size_str *= 1024;
+// source: https://stackoverflow.com/a/11807179
+function toBytes(string $from): ?int {
+    $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    $number = substr($from, 0, -2);
+    $suffix = strtoupper(substr($from,-2));
+
+    //B or no suffix
+    if(is_numeric(substr($suffix, 0, 1))) {
+        return preg_replace('/[^\d]/', '', $from);
     }
-    return (int)$size_str;
+
+    $exponent = array_flip($units)[$suffix] ?? null;
+    if($exponent === null) {
+        return null;
+    }
+
+    return $number * (1024 ** $exponent);
 }
 
 function endsWith($haystack, $needle, $ignoreCase){

--- a/workbench/util/RedisSessionHandler.php
+++ b/workbench/util/RedisSessionHandler.php
@@ -2,7 +2,7 @@
 
 //source: https://gist.github.com/zacharyrankin/51cc9fe809486be31ac4083af7631e66
 
-class RedisSessionHandler implements SessionHandlerInterface
+class RedisSessionHandler implements SessionHandlerInterface, SessionUpdateTimestampHandlerInterface
 {
     private Redis $redis;
     private int $ttl;
@@ -49,5 +49,15 @@ class RedisSessionHandler implements SessionHandlerInterface
         $this->redis->setEx($session_id, $this->ttl, $session_data);
 
         return true;
+    }
+
+    public function validateId($session_id)
+    {
+        return $this->read($session_id) != '';
+    }
+
+    public function updateTimestamp($session_id, $session_data)
+    {
+        return $this->write($session_id, $session_data);
     }
 }

--- a/workbench/util/RedisSessionHandler.php
+++ b/workbench/util/RedisSessionHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+//source: https://gist.github.com/zacharyrankin/51cc9fe809486be31ac4083af7631e66
+
+class RedisSessionHandler implements SessionHandlerInterface
+{
+    private Redis $redis;
+    private int $ttl;
+
+    public function __construct(Redis $redis, int $ttl)
+    {
+        $this->redis = $redis;
+        $this->ttl = $ttl;
+    }
+
+    public function close(): bool
+    {
+        return true;
+    }
+
+    public function destroy($session_id): bool
+    {
+        $this->redis->del($session_id);
+
+        return true;
+    }
+
+    public function gc($max_lifetime): int
+    {
+        return true;
+    }
+
+    public function open($path, $name): bool
+    {
+        return true;
+    }
+
+    public function read($session_id): string
+    {
+        if ($result = $this->redis->get($session_id)) {
+            return $result;
+        }
+
+        return '';
+    }
+
+    public function write($session_id, $session_data): bool
+    {
+        $this->redis->setEx($session_id, $this->ttl, $session_data);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Instead of using the `redis` `session.save_handler`, which does not yet support TLS, this uses a custom implementation of `SessionHandlerInterface` that wraps the existing Redis client, which supports TLS as of https://github.com/forceworkbench/forceworkbench/pull/858. 