### PR TITLE
Updated RestClient Curl request to force HTTP 1.1

### DIFF
--- a/workbench/restclient/RestClient.php
+++ b/workbench/restclient/RestClient.php
@@ -21,7 +21,7 @@ class RestApiClient {
 		if (!extension_loaded('curl')) {
 			throw new Exception('Missing required cURL extension.');
 		}
-	
+
         $this->baseUrl = $this->getBaseUrlFromPartnerEndpoint($partnerEndpoint);
         $this->sessionId = $sessionId;
     }
@@ -111,6 +111,7 @@ class RestApiClient {
                 throw new Exception($method . ' method not supported.');
         }
 
+        curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);              // Force HTTP 1.1
         curl_setopt($ch, CURLOPT_URL, $this->baseUrl . $path);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $httpHeaders);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, $expectBinary ? 0 : 1);
@@ -158,7 +159,7 @@ class RestApiClient {
         }
 
         $httpResponse = new HttpResponse($chResponse, $headerSize, $expectBinary);
-        
+
         curl_close($ch);
 
         return $httpResponse;
@@ -197,7 +198,7 @@ class RestApiClient {
 class HttpResponse {
     public $header;
     public $body;
-    
+
     public function __construct($curlResponse, $headerSize, $expectBinary) {
         if ($expectBinary) {
             $this->body = $curlResponse;


### PR DESCRIPTION
On newer servers, the curl library is using HTTP/2. This is causing issues due to the HTTP Response Status being "200" and not "200 OK" as expected in StreamingController.php on line 57.

ex: if (strpos($queryResponse->header, "200 OK") === false) {

Another resolution for this would be to remove OK from the if statement and only check for 200. 

ref: https://github.com/forceworkbench/forceworkbench/blob/c021d3007b597934bd0ff1dba54c3178cc7f9df1/workbench/controllers/StreamingController.php#L57