### PR TITLE
include api versions 59.0-62.0

### DIFF
--- a/workbench/config/defaults.php
+++ b/workbench/config/defaults.php
@@ -276,6 +276,10 @@ $config["header_LoginOptions"] = array(
     );
 
     $GLOBALS['API_VERSIONS'] = array(
+	"62.0" => "62.0",
+	"61.0" => "61.0",
+	"60.0" => "60.0",
+	"59.0" => "59.0",
         "58.0" => "58.0",
         "57.0" => "57.0",
         "56.0" => "56.0",
@@ -332,7 +336,7 @@ $config["header_LoginOptions"] = array(
     $config["defaultApiVersion"]  = array(
         "label" => "Default API Version",
         "description" => "Default API version to be used for login. This setting does not affect the API version of the current session. Recommended to choose latest version. Some features may act unexpectedly when using older versions.",
-        "default" => "58.0",
+        "default" => "62.0",
         "overrideable" => true,
         "dataType" => "picklist",
         "valuesToLabels" => $GLOBALS['API_VERSIONS']


### PR DESCRIPTION
- include missing api versions
- make v62.0 the default